### PR TITLE
fix issue where the src file/folder doesn't exist at the time of instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Add the plugin, reporter and reporter configuration in your `karma.conf.js`.
       lcovonly: 'path/to/output/coverage/lcov.info',
       html: 'path/to/output/html/report'
     },
-    timeoutNotCreated: 1000, // default value
-    timeoutNoMoreFiles: 1000 // default value
+    timeoutNotCreated: 1000 // default value
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var chokidar = require('chokidar');
 var remapIstanbul = require('remap-istanbul');
 
@@ -5,73 +6,70 @@ var KarmaRemapIstanbul = function (baseReporterDecorator, config) {
   baseReporterDecorator(this);
 
   var remapIstanbulReporterConfig = config.remapIstanbulReporter || {};
-  var sources = remapIstanbulReporterConfig.src || null;
+  var source = path.normalize(remapIstanbulReporterConfig.src) || null;
   var reports = remapIstanbulReporterConfig.reports || {};
   var timeoutNotCreated = remapIstanbulReporterConfig.timeoutNotCreated || 1000;
-  var timeoutNoMoreFiles = remapIstanbulReporterConfig.timeoutNoMoreFiles || 1000;
 
-  var pendingReport = 0;
   var reportFinished = function () { };
-  var noMoreFilesTimeout;
+  var timeoutNotCreatedInstance;
 
   this.onBrowserComplete = function (browser) {
-    if (!sources) return;
+    if (!source) return;
 
-    pendingReport++;
-    var addedPaths = 0;
+    // Extract directory path from file path
+    // Unfortunately `chokidar` - as well as other file watcher libs - doesn't
+    // work well on folders that haven't yet being created at instantiation time.
+    // As a work-around we watch the directory rather than the full filepath.
+    // See links below for more info:
+    // https://github.com/paulmillr/chokidar/issues/462
+    // https://github.com/paulmillr/chokidar/issues/346
+    var dir = path.dirname(source);
 
-    // Add watcher for source files
-    var watcher = chokidar.watch(sources, {
-      awaitWriteFinish: {
-        stabilityThreshold: 500,
-        pollInterval: 100
-      }
-    }).on('add', function (path) {
-      addedPaths++;
-      clearTimeout(noMoreFilesTimeout);
+    // If there's no folder in the filepath - eg. `example.json` than we
+    // use the filename itself.
+    dir === '.' ? source : dir;
 
-      if (addedPaths >= sources.length) {
+    // Add watcher for source file/folder
+    var watcher = chokidar
+      .watch(dir, {
+        awaitWriteFinish: {
+          stabilityThreshold: 500,
+          pollInterval: 100
+        },
+        usePolling: true
+      })
+      .on('add', function (path) {
+        if (path != source) return;
+
         remap(watcher);
-      }
-
-      // If no more files are found after "timeoutNoMoreFiles" call remap, even though
-      // we have not found all files specified in sources, and add warning
-      noMoreFilesTimeout = setTimeout(function () {
-        console.warn("Not all files specified in sources could be found, continue with partial remapping.");
-        remap(watcher);
-      }, timeoutNoMoreFiles);
-    });
+        clearTimeout(timeoutNotCreatedInstance);
+      });
 
     // Check if no file is found after "timeoutNotCreated", close watcher and exit with
-    // a warning
-    setTimeout(function () {
-      if (!addedPaths) {
-        watcher.close();
-        console.warn("Couldn't find any specified files, exiting without doing anything.");
-        reportFinished();
-      }
+    // a warning.
+    timeoutNotCreatedInstance = setTimeout(function () {
+      watcher.close();
+      console.warn('[karma-remap-istanbul]', 'Couldn\'t find any specified files, exiting without doing anything.');
+      reportFinished();
     }, timeoutNotCreated);
 
   };
 
   this.onExit = function (done) {
-    if (pendingReport) {
-      reportFinished = done;
-    } else {
-      done();
-    }
+    reportFinished = done;
   };
 
-  /**
-   * Close the chokidar file watcher and call remap-istanbul and exit
-   * plugin execution after successfull or erroneous return value from remapIstanbul
-   */
+  // Close the chokidar file watcher and call remap-istanbul and exit
+  // plugin execution after successfull or erroneous return value from remapIstanbul
   function remap(watcher) {
     watcher.close();
 
-    remapIstanbul(sources, reports).then(
+    remapIstanbul(source, reports).then(
       function (response) { reportFinished(); },
-      function (errorResponse) { console.warn(errorResponse); reportFinished(); }
+      function (errorResponse) {
+        console.warn('[karma-remap-istanbul]', errorResponse);
+        reportFinished();
+      }
     );
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-remap-istanbul",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Call remap-istanbul as a karma reporter, enabling remapped reports on watch",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
- remapIstanbul only accepts one json file per report which means we can:
  - rename sources to source
  - remove timeoutNoMoreFiles, pendingReport, noMoreFilesTimeout and addedPaths variables
- add prefix [karma-remap-istanbul] to console warnings
- normalize source path
- bump version to 0.0.6
- fix #3 

Please let me know your thoughts.
