### PR TITLE
Bump remap-istanbul version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/marcules/karma-remap-istanbul#readme",
   "dependencies": {
     "chokidar": "^1.4.2",
-    "remap-istanbul": "^0.5.1"
+    "remap-istanbul": "^0.6.4"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
This version of remap-istanbul introduces fix to absolute paths in source maps.
