### PR TITLE
If file watch notifications fail remap gracefully checks for the file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-remap-istanbul",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Call remap-istanbul as a karma reporter, enabling remapped reports on watch",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
I've been getting errors where the file watcher (chokidir) doesn't fire its `on` `add` event.  This has happened on Windows and OS X.  It's an intermittent issue.  Looks like other people here have similar issues _sometimes_: https://github.com/marcules/karma-remap-istanbul/issues/2 https://github.com/marcules/karma-remap-istanbul/issues/3

This patch manually checks for the file on timeout and if it exists it proceeds.  If it doesn't exist it still fails.
