### PR TITLE
Prevent karma zombie processes when running karma continuously

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
     // a warning
     setTimeout(function () {
       if (addedPaths === 0) {
+        pendingReport--;
         watcher.close();
         log.warn('Could not find any specified files, exiting without doing anything.');
         reportFinished();
@@ -75,6 +76,7 @@ var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
    * plugin execution after successfull or erroneous return value from remapIstanbul
    */
   function remap(watcher) {
+    pendingReport--;
     watcher.close();
 
     remapIstanbul(sources, reports).then(


### PR DESCRIPTION
Currently when running karma with `autoWatch: true` and `singleRun: false` and cancelling and restarting the test watcher it results in karma still hanging in the background like so:
<img width="697" alt="screen shot 2016-07-03 at 15 12 44" src="https://cloud.githubusercontent.com/assets/6425649/16545914/a3e526ce-4130-11e6-96cd-744c0a4a59a9.png">
