### PR TITLE
Change timing to OnRunComplete for getting the correct results

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
   var reportFinished = function () { };
   var noMoreFilesTimeout;
 
-  this.onBrowserComplete = function (browser) {
+  this.onRunComplete = function (browser) {
     if (!sources) return;
 
     pendingReport++;


### PR DESCRIPTION
Due to using onBrowserComplete the timing is wrong for the remap-istanbul and it uses the previous coverage files. With onRunComplete is updates correctly
