### PR TITLE
Use new _onWriteReport callback to remap files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,37 @@
 # karma-remap-istanbul
-Call remap-istanbul as a karma reporter, enabling remapped reports on watch
+Call remap-istanbul after `karma-coverage` has completed.
 
 ## installation
 
-Install `karma-remap-istanbul` as a dev-dependency in your project.
+Install `karma-remap-istanbul` and `karma-coverage` as a dev-dependency in your project.
 
 ```bash
-npm install karma-remap-istanbul --save-dev
+npm install karma-remap-istanbul karma-coverage --save-dev
 ```
 
 ## configuration
 
-Add the plugin, reporter and reporter configuration in your `karma.conf.js`.
+Add the plugin, reporter and reporter configuration in your `karma.conf.js`. The configuration options are the same as for the `karma-coverage` plugin. The possible reporter options can be found in the [karma-coverage](https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md)
+documentation;
 
 ```js
-{
-  plugins: ['karma-remap-istanbul'],
-  reporters: ['progress', 'karma-remap-istanbul'],
-  remapIstanbulReporter: {
-    src: 'path/to/generated/coverage/report.json',
-    reports: {
-      lcovonly: 'path/to/output/coverage/lcov.info',
-      html: 'path/to/output/html/report'
-    },
-    timeoutNotCreated: 1000, // default value
-    timeoutNoMoreFiles: 1000 // default value
-  }
-}
+module.exports = function (config) {
+    config.set({
+      plugins: ['karma-remap-istanbul'],
+      reporters: ['progress', 'remap-istanbul'],
+      coverageReporter: {
+        reporters: [
+          {
+            type: 'json',
+            subdir: '.', 
+            file: 'coverage-final.json'
+          },
+          {
+            type: 'html',
+            subdir: 'html'
+          }
+        ]
+      }
+  });
+};
 ```
-
-### Example configuration with `karma-coverage`
-```js
-{
-  preprocessors: {
-    'build/**/!(*spec).js': ['coverage']
-  },
-  plugins: ['karma-remap-istanbul', 'karma-coverage'],
-  reporters: ['progress', 'coverage', 'karma-remap-istanbul'],
-  coverageReporter: {
-    reporters: [{
-      type: 'json',
-      subdir: '.', 
-      file: 'coverage-final.json'
-    }]
-  },
-  remapIstanbulReporter: {
-    src: 'coverage/coverage-final.json',
-    reports: {
-      html: 'coverage'
-    },
-    timeoutNotCreated: 1000,
-    timeoutNoMoreFiles: 1000
-  }
-}
-```
-
-
-You may want to install `karma-coverage` and register it as a reporter before `karma-remap-istanbul` for this reporter to be sensible. The src can be either a string to a json file or array to multiple json files, which will be processed in one report. This, and the possible reporter options can be found in the [remap-istanbul](https://github.com/SitePen/remap-istanbul) project README.

--- a/index.js
+++ b/index.js
@@ -1,96 +1,25 @@
-var chokidar = require('chokidar');
 var remapIstanbul = require('remap-istanbul');
+var karmaCoverageReport = require('karma-coverage/lib/reporter');
 
-function getSourcesCount(sources) {
-  if (Array.isArray(sources)) { return sources.length; }
-  if (typeof sources === 'string') { return 1; }
-
-  return null;
-}
-
-var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
-  baseReporterDecorator(this);
+var KarmaRemapIstanbul = function (rootConfig, helper, logger, emitter) {
 
   var log = logger.create('reporter.remap-istanbul');
 
-  var remapIstanbulReporterConfig = config.remapIstanbulReporter || {};
-  var sources = remapIstanbulReporterConfig.src || null;
-  var reports = remapIstanbulReporterConfig.reports || {};
-  var timeoutNotCreated = remapIstanbulReporterConfig.timeoutNotCreated || 1000;
-  var timeoutNoMoreFiles = remapIstanbulReporterConfig.timeoutNoMoreFiles || 1000;
-
-  var sourcesCount = getSourcesCount(sources);
-  var pendingReport = 0;
-  var reportFinished = function () { };
-  var noMoreFilesTimeout;
-
-  this.onRunComplete = function (browser) {
-    if (!sources) return;
-
-    pendingReport++;
-    var addedPaths = 0;
-
-    // Add watcher for source files
-    var watcher = chokidar.watch(sources, {
-      awaitWriteFinish: {
-        stabilityThreshold: 500,
-        pollInterval: 100
-      }
-    }).on('add', function (path) {
-      addedPaths++;
-      clearTimeout(noMoreFilesTimeout);
-
-      if (addedPaths >= sourcesCount) {
-        remap(watcher);
-      } else {
-        noMoreFilesTimeout = setTimeout(function () {
-          log.warn('Not all files specified in sources could be found, continue with partial remapping.');
-          remap(watcher);
-        }, timeoutNoMoreFiles);
-      }
-    });
-
-    // Check if no file is found after "timeoutNotCreated", close watcher and exit with
-    // a warning
-    setTimeout(function () {
-      if (addedPaths === 0) {
-        pendingReport--;
-        watcher.close();
-        log.warn('Could not find any specified files, exiting without doing anything.');
-        reportFinished();
-      }
-    }, timeoutNotCreated);
-
-  };
-
-  this.onExit = function (done) {
-    if (pendingReport) {
-      reportFinished = done;
-    } else {
-      done();
+  var config = rootConfig.coverageReporter = rootConfig.coverageReporter || {};
+  config._onWriteReport = function (collector) {
+    try {
+      collector = remapIstanbul.remap(collector.getFinalCoverage());
+    } catch(e) {
+      log.error(e);
     }
+    return collector;
   };
 
-  /**
-   * Close the chokidar file watcher and call remap-istanbul and exit
-   * plugin execution after successfull or erroneous return value from remapIstanbul
-   */
-  function remap(watcher) {
-    pendingReport--;
-    watcher.close();
-
-    remapIstanbul(sources, reports).then(
-      function (response) { reportFinished(); },
-      function (errorResponse) {
-        log.warn(errorResponse);
-        reportFinished();
-      }
-    );
-  }
+  karmaCoverageReport.call(this, rootConfig, helper, logger, emitter);
 };
 
-KarmaRemapIstanbul.$inject = ['baseReporterDecorator', 'logger', 'config'];
+KarmaRemapIstanbul.$inject = karmaCoverageReport.$inject;
 
 module.exports = {
-  'reporter:karma-remap-istanbul': ['type', KarmaRemapIstanbul]
+  'reporter:remap-istanbul': ['type', KarmaRemapIstanbul]
 };

--- a/package.json
+++ b/package.json
@@ -16,16 +16,20 @@
     "karma-reporter"
   ],
   "author": "Marc A. Harnos <mharnos@gmail.com>",
+  "contributors": [{
+    "name": "Thomas Mair",
+    "email": "thomas.mair86@gmail.com"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/marcules/karma-remap-istanbul/issues"
   },
   "homepage": "https://github.com/marcules/karma-remap-istanbul#readme",
   "dependencies": {
-    "chokidar": "^1.5.1",
     "remap-istanbul": "^0.6.4"
   },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": ">=0.9",
+    "karma-coverage": ">=1.1.0"
   }
 }


### PR DESCRIPTION
The `karma-coverage` plugin gained the ability to notify a consumer about a report being written. I changed the `karma-remap-istanbul` plugin to use the `karma-coverage` plugin. The advantage of it is that the file watching is not needed anymore.

The following changes where made:
- removed dependency on `chokidar`
- added dependency on `karma-coverage`
- call remapping on karama-coverage `_onWriteReport` hook
