### PR TITLE
Remap coverage directly from `coverage` property instead of using a file watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,10 @@ Add the plugin, reporter and reporter configuration in your `karma.conf.js`.
   plugins: ['karma-remap-istanbul'],
   reporters: ['progress', 'karma-remap-istanbul'],
   remapIstanbulReporter: {
-    src: 'path/to/generated/coverage/report.json',
     reports: {
       lcovonly: 'path/to/output/coverage/lcov.info',
       html: 'path/to/output/html/report'
-    },
-    timeoutNotCreated: 1000, // default value
-    timeoutNoMoreFiles: 1000 // default value
+    }
   }
 }
 ```
@@ -37,23 +34,12 @@ Add the plugin, reporter and reporter configuration in your `karma.conf.js`.
   },
   plugins: ['karma-remap-istanbul', 'karma-coverage'],
   reporters: ['progress', 'coverage', 'karma-remap-istanbul'],
-  coverageReporter: {
-    reporters: [{
-      type: 'json',
-      subdir: '.', 
-      file: 'coverage-final.json'
-    }]
-  },
   remapIstanbulReporter: {
-    src: 'coverage/coverage-final.json',
     reports: {
       html: 'coverage'
-    },
-    timeoutNotCreated: 1000,
-    timeoutNoMoreFiles: 1000
+    }
   }
 }
 ```
 
-
-You may want to install `karma-coverage` and register it as a reporter before `karma-remap-istanbul` for this reporter to be sensible. The src can be either a string to a json file or array to multiple json files, which will be processed in one report. This, and the possible reporter options can be found in the [remap-istanbul](https://github.com/SitePen/remap-istanbul) project README.
+You will need to either install `karma-coverage` and configure it as a preprocessor for your transpiled modules under test or instrument the modules under test as part of your build process. If the latter option is chosen, the coverage statistics will need to be stored at the `__coverage__` global variable (istanbul's default) or karma will not transmit them back to the runner.

--- a/index.js
+++ b/index.js
@@ -1,12 +1,8 @@
-var chokidar = require('chokidar');
-var remapIstanbul = require('remap-istanbul');
+/* globals WeakMap, Promise */
 
-function getSourcesCount(sources) {
-  if (Array.isArray(sources)) { return sources.length; }
-  if (typeof sources === 'string') { return 1; }
-
-  return null;
-}
+var istanbul = require('istanbul');
+var remap = require('remap-istanbul/lib/remap');
+var writeReport = require('remap-istanbul/lib/writeReport');
 
 var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
   baseReporterDecorator(this);
@@ -14,79 +10,70 @@ var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
   var log = logger.create('reporter.remap-istanbul');
 
   var remapIstanbulReporterConfig = config.remapIstanbulReporter || {};
-  var sources = remapIstanbulReporterConfig.src || null;
   var reports = remapIstanbulReporterConfig.reports || {};
-  var timeoutNotCreated = remapIstanbulReporterConfig.timeoutNotCreated || 1000;
-  var timeoutNoMoreFiles = remapIstanbulReporterConfig.timeoutNoMoreFiles || 1000;
 
-  var sourcesCount = getSourcesCount(sources);
-  var pendingReport = 0;
+  var coverageMap;
+
+  this.onRunStart = function (browsers) {
+    coverageMap = new WeakMap();
+  };
+
+  this.onBrowserComplete = function (browser, result) {
+    if (!result || !result.coverage) {
+      return;
+    }
+
+    coverageMap.set(browser, result.coverage);
+  };
+
   var reportFinished = function () { };
-  var noMoreFilesTimeout;
 
-  this.onRunComplete = function (browser) {
-    if (!sources) return;
+  this.onRunComplete = function (browsers) {
+    // Collect the unmapped coverage information for all browsers in this run
+    var unmappedCoverage = (function () {
+      var collector = new istanbul.Collector();
 
-    pendingReport++;
-    var addedPaths = 0;
+      browsers.forEach(function (browser) {
+        var coverage = coverageMap.get(browser);
 
-    // Add watcher for source files
-    var watcher = chokidar.watch(sources, {
-      awaitWriteFinish: {
-        stabilityThreshold: 500,
-        pollInterval: 100
-      }
-    }).on('add', function (path) {
-      addedPaths++;
-      clearTimeout(noMoreFilesTimeout);
+        if (!coverage) {
+          return;
+        }
 
-      if (addedPaths >= sourcesCount) {
-        remap(watcher);
-      } else {
-        noMoreFilesTimeout = setTimeout(function () {
-          log.warn('Not all files specified in sources could be found, continue with partial remapping.');
-          remap(watcher);
-        }, timeoutNoMoreFiles);
-      }
-    });
+        collector.add(coverage);
+      });
 
-    // Check if no file is found after "timeoutNotCreated", close watcher and exit with
-    // a warning
-    setTimeout(function () {
-      if (addedPaths === 0) {
-        pendingReport--;
-        watcher.close();
-        log.warn('Could not find any specified files, exiting without doing anything.');
-        reportFinished();
-      }
-    }, timeoutNotCreated);
+      return collector.getFinalCoverage();
+    })();
 
+    var sourceStore = istanbul.Store.create('memory');
+    var collector = remap(unmappedCoverage, { sources: sourceStore });
+
+    Promise.all(Object.keys(reports).map(function (reportType) {
+      var destination = reports[reportType];
+
+      log.debug('Writing coverage to %s', destination);
+
+      return writeReport(collector, reportType, {}, destination, sourceStore);
+    })).catch(function (error) {
+      log.error(error);
+    }).then(function () {
+      collector.dispose();
+      coverageMap = null;
+
+      reportFinished();
+
+      // Reassign `onExit` to just call `done` since all reports have been written
+      this.onExit = function (done) {
+        done();
+      };
+    }.bind(this));
   };
 
   this.onExit = function (done) {
-    if (pendingReport) {
-      reportFinished = done;
-    } else {
-      done();
-    }
+    // Reports have not been written, so assign `done` to `reportFinished`
+    reportFinished = done;
   };
-
-  /**
-   * Close the chokidar file watcher and call remap-istanbul and exit
-   * plugin execution after successfull or erroneous return value from remapIstanbul
-   */
-  function remap(watcher) {
-    pendingReport--;
-    watcher.close();
-
-    remapIstanbul(sources, reports).then(
-      function (response) { reportFinished(); },
-      function (errorResponse) {
-        log.warn(errorResponse);
-        reportFinished();
-      }
-    );
-  }
 };
 
 KarmaRemapIstanbul.$inject = ['baseReporterDecorator', 'logger', 'config'];

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/marcules/karma-remap-istanbul#readme",
   "dependencies": {
-    "chokidar": "^1.5.1",
+    "istanbul": "^0.4.3",
     "remap-istanbul": "^0.6.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
This pull request removes all file watching and instead runs the coverage object returned from karma directly through `remap-istanbul`.

Related: https://github.com/angular/angular-cli/pull/1468
