### PR TITLE
Merge collector's store into sourceStore

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,12 @@ var KarmaRemapIstanbul = function (baseReporterDecorator, logger, config) {
     var sourceStore = istanbul.Store.create('memory');
     var collector = remap(unmappedCoverage, { sources: sourceStore });
 
+    collector.store.keys().forEach(function(key) {
+      if (!sourceStore.hasKey(key)) {
+        sourceStore.set(key, collector.store.get(key));
+      }
+    });
+
     Promise.all(Object.keys(reports).map(function (reportType) {
       var destination = reports[reportType];
 


### PR DESCRIPTION
If the sources are not inlined, the source store provided to the remap
function will not contain the sources. Therefore the sources returned by
the collector's store are merged into the provided sourceStore for the
report wirter to be used during report generation.
